### PR TITLE
Improved Cpp generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all: smc
+
+smc: 
+	ant compile
+	ant jar
+
+clean:
+	ant clean
+

--- a/src/smc/generators/nestedSwitchCaseGenerator/NSCGenerator.java
+++ b/src/smc/generators/nestedSwitchCaseGenerator/NSCGenerator.java
@@ -37,6 +37,11 @@ public class NSCGenerator {
   private void addStateCases(OptimizedStateMachine sm) {
     for (OptimizedStateMachine.Transition t : sm.transitions)
       addStateCase(stateSwitch, t);
+    addDefaultStateCase(stateSwitch);
+  }
+
+  private void addDefaultStateCase(NSCNode.SwitchCaseNode stateSwitch) {
+    stateSwitch.caseNodes.add(new NSCNode.DefaultCaseNode("Invalid State"));
   }
 
   private void addStateCase(NSCNode.SwitchCaseNode stateSwitch, OptimizedStateMachine.Transition t) {

--- a/src/smc/implementers/CppNestedSwitchCaseImplementer.java
+++ b/src/smc/implementers/CppNestedSwitchCaseImplementer.java
@@ -74,8 +74,13 @@ public class CppNestedSwitchCaseImplementer implements NSCNodeVisitor {
       "class %s : public %s {\n" +
       "public:\n" +
       "\t%s()\n\t: state(", fsmName, actionsName,fsmName);
+
     fsmClassNode.stateProperty.accept(this);
     output += ")\n\t{}\n\n";
+
+    // Add virtual destructor
+    output += String.format("\n" +
+        "\tvirtual ~%s() {}\n", fsmName);
 
     fsmClassNode.delegators.accept(this);
     output += "\nprivate:\n";
@@ -83,6 +88,7 @@ public class CppNestedSwitchCaseImplementer implements NSCNodeVisitor {
     output += "\tState state;\n";
     output += "\tvoid setState(State s) {state=s;}\n";
     fsmClassNode.eventEnum.accept(this);
+
     fsmClassNode.handleEvent.accept(this);
 
     output += "};\n\n";


### PR DESCRIPTION
- Added some changes to implement a default transition for states in order to compile Cpp code when -Wdefault-switch and -Werror are used. Typical case: the default Makefile for CppUTest.
- Added a virtual default destructor which makes possible to instantiate and delete StateMachine objects in the setup and teardown methods of a test harness.